### PR TITLE
Add a nix flake with default devshell and nix-direnv

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ target
 Cargo.lock
 .vscode
 README.html
+/.direnv/

--- a/examples/haskell/caryatid-haskell-interop.cabal
+++ b/examples/haskell/caryatid-haskell-interop.cabal
@@ -14,7 +14,7 @@ common warnings
 executable caryatid-haskell-interop
     import:           warnings
     main-is:          Main.hs
-    build-depends:    base ^>=4.14.3.0,
+    build-depends:    base,
                       amqp >=0.18.1,
                       cborg >=0.2.0.0,
                       bytestring,

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,93 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "naersk": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1733346208,
+        "narHash": "sha256-a4WZp1xQkrnA4BbnKrzJNr+dYoQr5Xneh2syJoddFyE=",
+        "owner": "nix-community",
+        "repo": "naersk",
+        "rev": "378614f37a6bee5a3f2ef4f825a73d948d3ae921",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "naersk",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1732981179,
+        "narHash": "sha256-F7thesZPvAMSwjRu0K8uFshTk3ZZSNAsXTIFvXBT+34=",
+        "path": "/nix/store/ljk3wvwqqzbmz0pys49ii18qmsi5aibc-source",
+        "rev": "62c435d93bf046a5396f3016472e8f7c8e2aed65",
+        "type": "path"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1736061677,
+        "narHash": "sha256-DjkQPnkAfd7eB522PwnkGhOMuT9QVCZspDpJJYyOj60=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "cbd8ec4de4469333c82ff40d057350c30e9f7d36",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "naersk": "naersk",
+        "nixpkgs": "nixpkgs_2"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,38 @@
+{
+  description = "The Caryatid framework for cardano";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
+    flake-utils.url = "github:numtide/flake-utils";
+    naersk.url = "github:nix-community/naersk";
+  };
+
+  outputs =
+    inputs@{ self
+    , flake-utils
+    , nixpkgs
+    , naersk
+    , ...
+    }:
+    flake-utils.lib.eachSystem flake-utils.lib.defaultSystems (system:
+    let
+      pkgs = nixpkgs.legacyPackages.${system};
+    in
+    {
+      inherit inputs;
+
+      # TODO: build rust packages using naersk
+
+      devShells.default = pkgs.mkShell {
+        buildInputs = [
+          # Rust build tools
+          pkgs.rustc
+          pkgs.cargo
+          pkgs.rust-analyzer
+          # Haskell build tools
+          pkgs.ghc
+          pkgs.cabal-install
+        ];
+      };
+    });
+}


### PR DESCRIPTION
This will allow nix-users to easily load development tools via `nix develop` or using `direnv`. Later on, we can package things using nix too (if we want).

Also removes the bounds on `base` in the haskell example to allow compilation with newer compilers.