### PR TITLE
feat: Support query parameters in RESTRequest

### DIFF
--- a/modules/rest_server/src/messages.rs
+++ b/modules/rest_server/src/messages.rs
@@ -1,5 +1,7 @@
 //! Messages for REST server module
 
+use std::collections::HashMap;
+
 /// REST request message
 #[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize)]
 pub struct RESTRequest {
@@ -14,6 +16,9 @@ pub struct RESTRequest {
 
     /// Request body (if any)
     pub body: String,
+
+    /// Request query parameters
+    pub query_parameters: HashMap<String, String>,
 }
 
 /// REST response message


### PR DESCRIPTION
This PR:
* Collects` req.uri().query()` into a `HashMap<String, String>` with keys as the query names and values as query values.
* Adds a `query_parameters` field to `RESTRequest` to expose query parameters to downstream modules.