### PR TITLE
bump rest_server to v0.14.0, adding query_parameters to RESTRequest

### DIFF
--- a/modules/rest_server/Cargo.toml
+++ b/modules/rest_server/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "caryatid_module_rest_server"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 authors = ["Paul Clark <paul.clark@iohk.io>"]
 description = "REST server module for Caryatid"


### PR DESCRIPTION
This PR updates `rest_server` to v0.14.0, publishing a new crate via automated CI. The newly added `query_parameters` field in RESTRequest will be used by the `/drdd?epoch={num}` and `/spdd?epoch={num}` endpoints in Acropolis. 