### PR TITLE
chore: replace unmaintained dependencies

### DIFF
--- a/process/Cargo.toml
+++ b/process/Cargo.toml
@@ -1,7 +1,7 @@
 # Caraytid process - loads and runs modules
 [package]
 name = "caryatid_process"
-version = "0.12.1"
+version = "0.12.2"
 edition = "2021"
 authors = ["Paul Clark <paul.clark@iohk.io>"]
 description = "Library for building a Caryatid process"
@@ -13,13 +13,13 @@ futures = "0.3"
 anyhow = "1.0"
 tokio = { version = "1", features = ["full"] }
 config = "0.15.11"
+minicbor-serde = { version = "0.6", features = ["alloc"] }
 tracing = "0.1.40"
 serde = "1.0.210"
 serde_json = "1.0"
-serde_cbor = "0.11.2"
 tracing-subscriber = "0.3.18"
-lapin = "2.5.3"
-tokio-executor-trait = "2.1.3"
+lapin = "3.7.1"
+tokio-executor-trait = "3.1.0"
 async-trait = "0.1.88"
 
 [lib]

--- a/process/src/rabbit_mq_bus.rs
+++ b/process/src/rabbit_mq_bus.rs
@@ -43,7 +43,7 @@ impl<M: MessageBounds> Subscription<M> for RabbitMQSubscription<M> {
                         .with_context(|| "Failed to acknowledge message")?;
 
                     // Decode it
-                    match serde_cbor::de::from_slice::<M>(&delivery.data) {
+                    match minicbor_serde::from_slice(&delivery.data) {
                         Ok(message) => {
                             // Call the subscriber function with the message
                             return Ok((delivery.routing_key.to_string(), Arc::new(message)));
@@ -130,7 +130,7 @@ impl<M: MessageBounds + serde::Serialize + serde::de::DeserializeOwned> MessageB
         let channel = self.channel.lock().await;
 
         // Serialise the message
-        let payload = serde_cbor::ser::to_vec(&*message)?;
+        let payload = minicbor_serde::to_vec(&*message)?;
 
         // Publish the message to the queue
         channel


### PR DESCRIPTION
Update dependencies in `process` so that it passes `cargo audit` without any warnings.

- Replace `serde_cbor` with `minicbor_serde`. The `serde_cbor` crate is long unmaintained; `minicbor` is the standard CBOR crate in the rust Cardano ecosystem, and `minicbor_serde` is a mostly drop-in `serde_cbor` replacement.
- Update `lapin` and `tokio-executor-trait` to the latest major versions. Gets rid of some old transitive dependencies.

These deps are all used by the rabbitmq router and nowhere else, so I don't think there's any risk of regression.