### PR TITLE
fix: publish old changes to macros crate

### DIFF
--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "caryatid_sdk"
-version = "0.13.0"
+version = "0.13.1"
 edition = "2021"
 authors = ["Paul Clark <paul.clark@iohk.io>"]
 description = "The Caryatid framework module SDK"
@@ -14,7 +14,7 @@ anyhow = "1.0"
 futures = "0.3"
 serde_json = "1.0"
 config = "0.15.11"
-caryatid_macros = { version="0.7", path = "macros" }
+caryatid_macros = { version="0.8", path = "macros" }
 tracing = "0.1.40"
 serde = { version = "1.0.214", features = ["derive"] }
 chrono = { version = "0.4", features = ["serde"] }

--- a/sdk/macros/Cargo.toml
+++ b/sdk/macros/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "caryatid_macros"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 authors = ["Paul Clark <paul.clark@iohk.io>"]
 description = "Procedural macros for the Caryatid framework module SDK"


### PR DESCRIPTION
Building the latest version of some crates fails because we never published the module change it relies on. Do so now.